### PR TITLE
refactor unresolved descendants

### DIFF
--- a/src/build-schema.js
+++ b/src/build-schema.js
@@ -2,10 +2,10 @@
 
 // imports
 const path = require("path");
-const parseFile = require("./parseFile");
-const getSchema = require("./getSchema");
-const resolveFilePath = require("./resolveFilePath");
-const readSourceFile = require("./readSourceFile");
+const getParsedCode = require("./getParsedCode");
+const getComponents = require("./getComponents");
+const getRelativeFilePath = require("./getRelativeFilePath");
+const getCode = require("./getCode");
 const parseImport = require("./parseImport");
 const resolveComponent = require("./resolveComponent");
 const { isFile, isDirectory, pathExists } = require("./utils/isFile");
@@ -14,12 +14,12 @@ const getAlias = require("./utils/getAlias");
 
 // INITIALIZING VARIABLES
 // warnings: an array to collect warnings related to insufficient data
-// components: an object to store the schema
+// componentsByUID: an object to store the schema
 // filesVisited: a Map to prevent multiple visits to the same file
 // importResolutions: a Map to prevent multiple resolutions for the same import path
 // stack: an array to organize visiting logic
 const warnings = [];
-const components = {};
+const componentsByUID = {};
 const filesVisited = new Map();
 const importResolutions = new Map();
 const stack = [];
@@ -87,8 +87,8 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
     const { entryPoint, componentName = "" } = stack.pop();
 
     // rely on this relative file path to hide the user's private file structure
-    const relativeFilePath = resolveFilePath(entryPoint, componentName);
-    // Guard Clause: on resolveFilePath() failure, log a warning and skip the current file
+    const relativeFilePath = getRelativeFilePath(entryPoint, componentName);
+    // Guard Clause: on getRelativeFilePath() failure, log a warning and skip the current file
     if (!relativeFilePath) {
       if (verbosity.verbose) {
         log(
@@ -108,13 +108,13 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
     filesVisited.set(relativeFilePath, true);
 
     // retrieve the file's code as a string
-    const code = readSourceFile(relativeFilePath);
+    const code = getCode(relativeFilePath);
 
-    // GENERATE SCHEMA
-    const parsedFile = parseFile(code);
-    const schema = getSchema(parsedFile, relativeFilePath);
-    // Guard Clause: on getSchema() failure, log a warning and skip the current file
-    if (!schema) {
+    // GET COMPONENTS
+    const parsedCode = getParsedCode(code);
+    const components = getComponents(parsedCode, relativeFilePath);
+    // Guard Clause: on getComponents() failure, log a warning and skip the current file
+    if (!components) {
       if (verbosity.verbose) {
         log(
           `(build-schema) failed to parse component "${componentName}" in the file "${relativeFilePath}"`,
@@ -126,27 +126,28 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
 
     // account for when multiple components are defined in the same file
     // create Unique IDs
-    Object.values(schema).forEach((component) => {
-      const alias = getAlias(parsedFile.assignmentExpressions, component.name);
+    Object.values(components).forEach((component) => {
+      const alias = getAlias(parsedCode.assignmentExpressions, component.name);
       // UID for default exported component is the component's imported name
       if (component.defaultExport) {
-        components[`${componentName}::${relativeFilePath}`] = component;
+        componentsByUID[`${componentName}::${relativeFilePath}`] = component;
         // UID for imported components that have an alias uses alias when available
       } else if (alias) {
-        components[`${alias}::${relativeFilePath}`] = component;
+        componentsByUID[`${alias}::${relativeFilePath}`] = component;
         // UID for all other components uses the assigned name of that component
       } else {
-        components[`${component.name}::${relativeFilePath}`] = component;
+        componentsByUID[`${component.name}::${relativeFilePath}`] = component;
       }
       // if this is the first parsed component
-      if (Object.keys(components).length === 1) {
+      if (Object.keys(componentsByUID).length === 1) {
         // mark it as the entry component
-        components[Object.keys(components)[0]]["isEntryComponent"] = true;
+        componentsByUID[Object.keys(componentsByUID)[0]]["isEntryComponent"] =
+          true;
       }
     });
 
     // if we received a valid componentName and it has not been resolved before,
-    if (componentName && !schema[`${componentName}::${relativeFilePath}`]) {
+    if (componentName && !components[`${componentName}::${relativeFilePath}`]) {
       // add it to our unresolved pile
       unresolvedComponents.push({
         componentName,
@@ -156,11 +157,11 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
 
     // UNRESOLVED DESCENDANTS
     // for each of the component's descendants,
-    Object.values(schema).forEach((component) => {
+    Object.values(components).forEach((component) => {
       component.unresolvedDescendants.forEach((unresolvedDescendant) => {
         // check if descendant is declared in the current file
         const unresolvedDescendantIsInCurrentFile =
-          schema[`${unresolvedDescendant}::${relativeFilePath}`];
+          components[`${unresolvedDescendant}::${relativeFilePath}`];
         // if so, set its location to the current file
         if (unresolvedDescendantIsInCurrentFile) {
           component["descendants"]?.set(unresolvedDescendant, {
@@ -175,7 +176,7 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
           importSource: descendantImportPath,
           localName,
           importedName,
-        } = parseImport(parsedFile.imports, unresolvedDescendant);
+        } = parseImport(parsedCode.imports, unresolvedDescendant);
         const importName = importedName ? importedName : localName;
         // remember imported Names when relevant, to resolve them later
         if (importName && unresolvedDescendant !== importName) {
@@ -304,13 +305,13 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
   importedNames.forEach(({ importName, filepath, unresolvedDescendant }) => {
     const filepathResolution = importResolutions.get(filepath);
     const relativeResolution = getRelativeFromAbsolutePath(filepathResolution);
-    components[`${unresolvedDescendant}::${relativeResolution}`] =
-      components[`${importName}::${relativeResolution}`];
+    componentsByUID[`${unresolvedDescendant}::${relativeResolution}`] =
+      componentsByUID[`${importName}::${relativeResolution}`];
   });
 
   // And, create a component for each node_modules file
   node_modules.forEach(({ unresolvedDescendant, descendantImportPath }) => {
-    components[`${unresolvedDescendant}::${descendantImportPath}`] = {
+    componentsByUID[`${unresolvedDescendant}::${descendantImportPath}`] = {
       name: unresolvedDescendant,
       description: "",
       type: "node_module",
@@ -334,7 +335,7 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
 
   // And ammend unresolved components
   unresolvedComponents.forEach(({ componentName, ID }) => {
-    if (!components[ID]) {
+    if (!componentsByUID[ID]) {
       const obj = {
         name: `${componentName}`,
         description: "",
@@ -346,7 +347,7 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
         unresolvedDescendants: undefined,
         unresolved: true,
       };
-      components[ID] = obj;
+      componentsByUID[ID] = obj;
       //console.log(`appended ${componentName} to schema as ${ID}`);
     }
   });
@@ -358,7 +359,7 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
 
   // log schema to the console for quick visual analysis
   if (verbosity.debug) {
-    console.dir(components, { depth: null, colors: true });
+    console.dir(componentsByUID, { depth: null, colors: true });
   }
   // log collected warnings
   if (verbosity.verbose || verbosity.debug) {
@@ -368,12 +369,12 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
   // log success message since we have completed the parsing and schema generation process
   if (!verbosity.quiet) {
     log(
-      `✅ Success: Parsed ${Object.keys(components).length} components from ${filesVisited.size} files in ${durationInMs} milliseconds`,
+      `✅ Success: Parsed ${Object.keys(componentsByUID).length} components from ${filesVisited.size} files in ${durationInMs} milliseconds`,
     );
   }
 
   // return schema object for optional further analysis
-  return components;
+  return componentsByUID;
 }
 
 module.exports = build_schema;

--- a/src/build-schema.js
+++ b/src/build-schema.js
@@ -123,18 +123,11 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
       }
       continue;
     }
-    if (componentName && !schema[`${componentName}::${relativeFilePath}`]) {
-      //console.log(`Could not find ${componentName} at ${relativeFilePath}`);
-      unresolvedComponents.push({
-        componentName,
-        ID: `${componentName}::${relativeFilePath}`,
-      });
-    }
 
     // account for when multiple components are defined in the same file
     // create Unique IDs
     Object.values(schema).forEach((component) => {
-      const alias = getAlias(code, component.name);
+      const alias = getAlias(parsedFile.assignmentExpressions, component.name);
       // UID for default exported component is the component's imported name
       if (component.defaultExport) {
         components[`${componentName}::${relativeFilePath}`] = component;
@@ -151,6 +144,15 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
         components[Object.keys(components)[0]]["isEntryComponent"] = true;
       }
     });
+
+    // if we received a valid componentName and it has not been resolved before,
+    if (componentName && !schema[`${componentName}::${relativeFilePath}`]) {
+      // add it to our unresolved pile
+      unresolvedComponents.push({
+        componentName,
+        ID: `${componentName}::${relativeFilePath}`,
+      });
+    }
 
     // UNRESOLVED DESCENDANTS
     // for each of the component's descendants,

--- a/src/build-schema.js
+++ b/src/build-schema.js
@@ -158,18 +158,8 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
     // UNRESOLVED DESCENDANTS
     // for each of the component's descendants,
     Object.values(components).forEach((component) => {
-      component.unresolvedDescendants.forEach((unresolvedDescendant) => {
-        // check if descendant is declared in the current file
-        const unresolvedDescendantIsInCurrentFile =
-          components[`${unresolvedDescendant}::${relativeFilePath}`];
-        // if so, set its location to the current file
-        if (unresolvedDescendantIsInCurrentFile) {
-          component["descendants"]?.set(unresolvedDescendant, {
-            location: { filepath: relativeFilePath },
-          });
-          return;
-        }
-        // otherwise,
+      component.unresolvedDescendants.forEach((fp, unresolvedDescendant) => {
+        //(filepath_unresolvedDescendant, unresolvedDescendant) => {
         // collect the descendant's import path
         // and importedName i.e. ComponentA as A if relevant
         const {
@@ -254,16 +244,18 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
           // Guard Clause: if the import statement of this descendant leads to a node_modules file
           // file path will be set to descendantImportPath
           // e.g. TooltipPrimitive::@radix-ui/react-tooltip
-          component.descendants?.set(unresolvedDescendant, {
-            location: { filepath: descendantImportPath },
-          });
+          component.unresolvedDescendants.set(
+            unresolvedDescendant,
+            descendantImportPath,
+          );
           // add path to node_modules
           node_modules.push({ unresolvedDescendant, descendantImportPath });
         } else {
           // update component's descendant's file path
-          component.descendants?.set(unresolvedDescendant, {
-            location: { filepath: resolvedImport_RelativeFilePath },
-          });
+          component.unresolvedDescendants.set(
+            unresolvedDescendant,
+            resolvedImport_RelativeFilePath,
+          );
           // if file has already been visited,
           if (filesVisited.get(resolvedImport_RelativeFilePath)) {
             // resolve remaining unresolved descendants
@@ -291,12 +283,12 @@ function build_schema(entryPoint, rootComponentName, verbosity = {}) {
           }
         }
       });
+      // transform component descendants from type Map to type Array
+      component.descendants = Array.from(
+        component.unresolvedDescendants.entries(),
+      ).map(([name, filepath]) => `${name}::${filepath}`);
       // clear and hide unresolvedDescendants from JSON file output
       component.unresolvedDescendants = undefined;
-      // transform component descendants from type Map to type Array
-      component.descendants = Array.from(component.descendants.entries()).map(
-        ([name, metadata]) => `${name}::${metadata.location.filepath}`,
-      );
     });
   }
 

--- a/src/collectTopLevelDeclarations.js
+++ b/src/collectTopLevelDeclarations.js
@@ -10,6 +10,7 @@ function collectTopLevelDeclarations(program_body) {
     regular_functions: [],
     classes: [],
     returnStatement: [],
+    assignmentExpressions: [],
   };
 
   const isFirstLetterCapitalized = (name) => /^[A-Z]/.test(name);
@@ -98,6 +99,7 @@ function collectTopLevelDeclarations(program_body) {
                       break;
                     }
                     case "Identifier":
+                    case "MemberExpression":
                     case "CallExpression":
                     case "JSXElement": {
                       topLevelDeclarations.constants.push({
@@ -145,6 +147,13 @@ function collectTopLevelDeclarations(program_body) {
         // stores return statements
         case "ReturnStatement": {
           topLevelDeclarations.returnStatement.push(bodyPath);
+          break;
+        }
+        case "ExpressionStatement": {
+          const expression = bodyPath.get("expression");
+          if (expression.isAssignmentExpression()) {
+            topLevelDeclarations.assignmentExpressions.push(bodyPath);
+          }
           break;
         }
       }

--- a/src/getCode.js
+++ b/src/getCode.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { transpileTSFile } = require("./utils/compileTS");
 
-function readSourceFile(inputPath) {
+function getCode(inputPath) {
   if (!inputPath) {
     console.error("ERROR: Please provide a file path.");
     process.exit(1);
@@ -26,4 +26,4 @@ function readSourceFile(inputPath) {
   }
 }
 
-module.exports = readSourceFile;
+module.exports = getCode;

--- a/src/getComponents.js
+++ b/src/getComponents.js
@@ -1,14 +1,14 @@
-// getSchema.js
+// getComponents.js
 
 //const parseFile = require("./parseFile");
 const verifyReactComponents = require("./verifyReactComponents");
 const parseReactComponents = require("./parseReactComponents");
 
-function getSchema(topLevelDeclarations, filePath) {
+function getComponents(parsedCode, filePath) {
   //const topLevelDeclarations = parseFile(sourceCode);
-  const verifiedComponents = verifyReactComponents(topLevelDeclarations);
+  const verifiedComponents = verifyReactComponents(parsedCode);
   const components = parseReactComponents(verifiedComponents, filePath);
   return components;
 }
 
-module.exports = getSchema;
+module.exports = getComponents;

--- a/src/getParsedCode.js
+++ b/src/getParsedCode.js
@@ -1,10 +1,10 @@
-// parseFile.js
+// getParsedCode.js
 
 const parser = require("@babel/parser");
 const traverse = require("@babel/traverse").default;
 const collectTopLevelDeclarations = require("./collectTopLevelDeclarations");
 
-function parseFile(sourceCode) {
+function getParsedCode(sourceCode) {
   const ast = parser.parse(sourceCode, {
     plugins: ["jsx", "typescript"],
     sourceType: "module",
@@ -23,4 +23,4 @@ function parseFile(sourceCode) {
   return topLevelDeclarations;
 }
 
-module.exports = parseFile;
+module.exports = getParsedCode;

--- a/src/getRelativeFilePath.js
+++ b/src/getRelativeFilePath.js
@@ -1,14 +1,14 @@
-// resolveFilePath.js
+// getRelativeFilePath.js
 // objective: find the file containing the declaration of a given component, the way a bundler does it */
 
 // imports
 const path = require("path");
 const fs = require("fs");
-const parseFile = require("./parseFile");
+const getParsedCode = require("./getParsedCode");
 const componentIsDeclaredInCode = require("./utils/componentIsDeclaredInCode");
 const { isFile, pathExists } = require("./utils/isFile");
 
-function resolveFilePath(entryPoint, componentName) {
+function getRelativeFilePath(entryPoint, componentName) {
   // store user's current working directory
   const projectRootDir = process.cwd();
 
@@ -52,7 +52,7 @@ function resolveFilePath(entryPoint, componentName) {
     if (pathExists(filePath)) {
       // scan the code
       const code = fs.readFileSync(filePath, "utf-8");
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const isEntryComponent = true;
       // if component's declaration is found,
       if (
@@ -73,4 +73,4 @@ function resolveFilePath(entryPoint, componentName) {
   return null;
 }
 
-module.exports = resolveFilePath;
+module.exports = getRelativeFilePath;

--- a/src/parseReactComponents.js
+++ b/src/parseReactComponents.js
@@ -11,6 +11,7 @@ function parseReactComponents(validatedComponents, filepath) {
     classes: [],
     exports: [],
   };
+  const resolvedDescendants = [];
   function extract(validatedComponents = []) {
     return validatedComponents.map(
       ({
@@ -20,7 +21,7 @@ function parseReactComponents(validatedComponents, filepath) {
         declaration,
         declaration_type,
         export_type,
-        verified,
+        verified = new Set(),
       }) => {
         const obj = {
           name: "",
@@ -30,7 +31,7 @@ function parseReactComponents(validatedComponents, filepath) {
           external: { props: [], context: [], constants: [] },
           defaultExport: export_type && export_type === "default",
           location: null,
-          unresolvedDescendants: new Set(),
+          unresolvedDescendants: new Map(),
         };
 
         const decl = declarator ? declarator : declaration;
@@ -177,13 +178,28 @@ function parseReactComponents(validatedComponents, filepath) {
 
           const returnStatementPath = internalDeclarations.returnStatement[0];
           //EXTRACT COMPONENT DESCENDANTS
-          extractComponentDescendants({ returnStatementPath, obj });
+          const resolvedDescendant = extractComponentDescendants({
+            returnStatementPath,
+            obj,
+            filepath,
+          });
+          if (resolvedDescendant) {
+            resolvedDescendants.push(resolvedDescendant);
+          }
         } // ---- END OF BLOCK STATEMENT CODE ---------------------------------------------
 
         //EXTRACT non-blockstatement COMPONENT DESCENDANTS (e.g. () => JSX in ArrowFunctionExpressions)
         else {
           const returnStatementPath = componentPath.get("body");
-          extractComponentDescendants({ returnStatementPath, obj });
+          const resolvedDescendant = extractComponentDescendants({
+            returnStatementPath,
+            obj,
+            filepath,
+          });
+
+          if (resolvedDescendant) {
+            resolvedDescendants.push(resolvedDescendant);
+          }
         }
 
         //EXTRACT externally defined props -> ["propA", "propB", "propC", ...]
@@ -230,11 +246,25 @@ function parseReactComponents(validatedComponents, filepath) {
     components[`${component.name}::${component.location.filepath}`] = component;
   });
 
+  resolvedDescendants.forEach((resolvedDescendant) => {
+    const [desc_key, desc_value] = resolvedDescendant;
+    // if descendant was not detected as a top level component
+    if (!components[desc_key]) {
+      // record it and label it as nested
+      components[desc_key] = desc_value;
+      components[desc_key].nested = true;
+    }
+  });
+
   return components;
 }
 
-function extractComponentDescendants({ returnStatementPath, obj }) {
-  const descendantsMap = new Map();
+function extractComponentDescendants({
+  returnStatementPath,
+  obj: component,
+  filepath,
+}) {
+  const tentativeDescendantsMap = new Map();
 
   function handleJSXElement(elementPath) {
     const opening = elementPath.node.openingElement;
@@ -254,28 +284,76 @@ function extractComponentDescendants({ returnStatementPath, obj }) {
       }
     }
 
+    // do not treat top-level component as a descendant
+    // PREVENTS INFINITE LOOP
+    if (tagName === component.name) return false;
+
     // Only add component-like elements (capitalized, not HTML tags)
     if (tagName && /^[A-Z]/.test(tagName)) {
-      // create a temporary list of this component's unresolved descendants
-      // (this list gets resolved in build-schema.js)
-      obj.unresolvedDescendants.add(tagName);
-      descendantsMap.set(tagName, {
-        location: {},
-      });
+      // set unresolved descendant to filepath "" temporarily
+      // (this tentative map gets resolved in build-schema.js)
+      tentativeDescendantsMap.set(tagName, "");
+
+      // check whether descendant is declared in the current filepath
+      // (if so, resolve filepath here instead of in build-schema.js)
+      const elementBinding = elementPath.scope.getBinding(tagName);
+
+      // if descendant is not declared anywhere, it could be global or unresolved
+      // Failed: could not resolve descendant within this filepath
+      if (!elementBinding) return false;
+
+      const bindingPath = elementBinding.path;
+      if (bindingPath) {
+        if (
+          bindingPath.isFunctionDeclaration() ||
+          bindingPath.isVariableDeclarator()
+        ) {
+          // parse descendant
+          const declaration = bindingPath.isVariableDeclarator()
+            ? bindingPath.parentPath
+            : bindingPath;
+          const declarations = collectTopLevelDeclarations([declaration]);
+          const descendants = parseReactComponents(
+            [
+              ...declarations.constants,
+              ...declarations.regular_constants,
+              ...declarations.functions,
+              ...declarations.regular_functions,
+            ],
+            filepath,
+          );
+          if (descendants[`${tagName}::${filepath}`]) {
+            // Success: resolved descendant
+            // remove resolved descendant from tentative Map
+            tentativeDescendantsMap.delete(tagName);
+            // add UID to component.descendants
+            component.descendants.push(`${tagName}::${filepath}`);
+            // add the parsed descendant to resolvedDescendants
+            const resolvedDescendant = Object.entries(descendants)[0];
+            return resolvedDescendant;
+          }
+          // Failed: could not resolve descendant within this filepath
+          return false;
+        }
+      }
     }
   }
 
+  let result = "";
   //EXTRACT component descendants
+  // When return is <Jsx/>
   if (returnStatementPath.isJSXElement()) {
-    handleJSXElement(returnStatementPath);
+    result = handleJSXElement(returnStatementPath);
+  } else {
+    // When return contains JSX
+    returnStatementPath.traverse({
+      JSXElement(elementPath) {
+        result = handleJSXElement(elementPath);
+      },
+    });
   }
-  (returnStatementPath.traverse({
-    JSXElement(elementPath) {
-      handleJSXElement(elementPath);
-    },
-  }),
-    (obj.descendants = descendantsMap));
-  obj.unresolvedDescendants = Array.from(obj.unresolvedDescendants);
+  component.unresolvedDescendants = tentativeDescendantsMap;
+  return result;
 }
 
 module.exports = parseReactComponents;

--- a/src/parseReactComponents.js
+++ b/src/parseReactComponents.js
@@ -23,7 +23,7 @@ function parseReactComponents(validatedComponents, filepath) {
         export_type,
         verified = new Set(),
       }) => {
-        const obj = {
+        const component = {
           name: "",
           description: "",
           descendants: [],
@@ -37,10 +37,10 @@ function parseReactComponents(validatedComponents, filepath) {
         const decl = declarator ? declarator : declaration;
 
         //EXTRACT name
-        obj.name = decl.node.id ? decl.node.id.name : "";
+        component.name = decl.node.id ? decl.node.id.name : "";
 
         //EXTRACT location
-        obj.location = {
+        component.location = {
           line: decl.node.loc.start.line,
           filepath,
         };
@@ -53,14 +53,14 @@ function parseReactComponents(validatedComponents, filepath) {
             declaration_type === "VariableDeclaration" &&
             decl.get("init").node.arguments[0].type === "Identifier"
           ) {
-            return obj;
+            return component;
           }
           // or export default memo(OtherComponent)
           if (
             declaration_type === "CallExpression" &&
             decl.node.arguments[0].type === "Identifier"
           ) {
-            return obj;
+            return component;
           }
           // otherwise this is probably a forwardRef( () => {} )
         }
@@ -115,7 +115,7 @@ function parseReactComponents(validatedComponents, filepath) {
 
           //EXTRACT function names --> [ "func1", "func2", ... ]
           // A. function-defined
-          obj.internal.functions = internalFunctionDeclarations
+          component.internal.functions = internalFunctionDeclarations
             .map((func) => func.node.id?.name)
             //.map((fn) => fn.node.id?.name) // access name if it exists
             .filter(Boolean); // filter out any undefined or null names
@@ -124,7 +124,7 @@ function parseReactComponents(validatedComponents, filepath) {
             .map(({ declarator }) => declarator.node.id?.name)
             .filter(Boolean);
           // append inline arrow functions
-          obj.internal.functions.push(...inline);
+          component.internal.functions.push(...inline);
 
           // helper function: verify reactHook is useState | useContext
           const isStateVariable = (path, reactHook) => {
@@ -148,7 +148,7 @@ function parseReactComponents(validatedComponents, filepath) {
           const state_values = useState_declarators.map(({ declarator }) =>
             declarator.node.id.elements.map((element) => element.name),
           );
-          obj.internal.states = state_values;
+          component.internal.states = state_values;
 
           // extract useContext declarators
           const context_declarators =
@@ -174,13 +174,13 @@ function parseReactComponents(validatedComponents, filepath) {
             }
             context.push({ source, values });
           });
-          obj.external.context = context;
+          component.external.context = context;
 
           const returnStatementPath = internalDeclarations.returnStatement[0];
           //EXTRACT COMPONENT DESCENDANTS
           const resolvedDescendant = extractComponentDescendants({
             returnStatementPath,
-            obj,
+            component,
             filepath,
           });
           if (resolvedDescendant) {
@@ -193,7 +193,7 @@ function parseReactComponents(validatedComponents, filepath) {
           const returnStatementPath = componentPath.get("body");
           const resolvedDescendant = extractComponentDescendants({
             returnStatementPath,
-            obj,
+            component,
             filepath,
           });
 
@@ -214,19 +214,21 @@ function parseReactComponents(validatedComponents, filepath) {
               param.get("properties").forEach((prop) => {
                 if (prop.isObjectProperty()) {
                   //CASE: prop type is an ObjectProperty
-                  obj.external.props.push(prop.node.key.name);
+                  component.external.props.push(prop.node.key.name);
                 } else if (prop.isRestElement()) {
                   // CASE: prop type is a RestElement
-                  obj.external.props.push(`...${prop.node.argument.name}`);
+                  component.external.props.push(
+                    `...${prop.node.argument.name}`,
+                  );
                 }
               });
               // if the parameter is an identifier (e.g. ref)
             } else if (param.isIdentifier()) {
-              obj.external.props.push(param.node.name);
+              component.external.props.push(param.node.name);
             }
           });
         }
-        return obj;
+        return component;
       },
     );
   }
@@ -261,7 +263,7 @@ function parseReactComponents(validatedComponents, filepath) {
 
 function extractComponentDescendants({
   returnStatementPath,
-  obj: component,
+  component,
   filepath,
 }) {
   const tentativeDescendantsMap = new Map();

--- a/src/utils/getAlias.js
+++ b/src/utils/getAlias.js
@@ -1,51 +1,24 @@
-const parser = require("@babel/parser");
-const traverse = require("@babel/traverse").default;
+//const parser = require("@babel/parser");
+//const traverse = require("@babel/traverse").default;
 
-function getAlias(code, componentName) {
-  // initialize variable
-  let alias = "";
+function getAlias(assignmentExpressions, componentName) {
+  // filter more to view only the displayName expression statements related to our component
+  const displayNameExpressionStatementPaths = assignmentExpressions
+    .map((path) => path.get("expression"))
+    .filter(
+      (p) =>
+        p.node.left.type === "MemberExpression" &&
+        p.node.left.object.name === componentName &&
+        p.node.left.property.type === "Identifier" &&
+        p.node.left.property.name === "displayName",
+    );
 
-  // create ast
-  const ast = parser.parse(code, {
-    sourceType: "module",
-    plugins: ["typescript", "jsx"],
-  });
+  // verify that alias is a string literal, then extract alias if one exists
+  const alias =
+    displayNameExpressionStatementPaths[0]?.node.right.type === "StringLiteral"
+      ? displayNameExpressionStatementPaths[0].node.right.value
+      : "";
 
-  // traverse ast
-  traverse(ast, {
-    // parse the Program (only one Program exists in an ast)
-    Program(programPath) {
-      // collect all top level expression statements inside of Program's body array
-      const expressionStatementPaths = programPath
-        .get("body")
-        .filter((path) => path.isExpressionStatement());
-
-      // filter to view only Assignment expression statements
-      const assignmentExpressionStatementPaths =
-        expressionStatementPaths.filter((path) =>
-          path.get("expression").isAssignmentExpression(),
-        );
-
-      // filter more to view only the displayName expression statements related to our component
-      const displayNameExpressionStatementPaths =
-        assignmentExpressionStatementPaths
-          .map((path) => path.get("expression"))
-          .filter(
-            (p) =>
-              p.node.left.type === "MemberExpression" &&
-              p.node.left.object.name === componentName &&
-              p.node.left.property.type === "Identifier" &&
-              p.node.left.property.name === "displayName",
-          );
-
-      // verify that alias is a string literal, then extract alias if one exists
-      alias =
-        displayNameExpressionStatementPaths[0]?.node.right.type ===
-        "StringLiteral"
-          ? displayNameExpressionStatementPaths[0].node.right.value
-          : "";
-    },
-  });
   return alias;
 }
 

--- a/tests/dataExtraction.test.js
+++ b/tests/dataExtraction.test.js
@@ -2,9 +2,10 @@
 // Goal: Ensure props, states, context, and functions are accurately extracted from components.
 // Cases Covered: props, state, context
 //const parseCode = require("../src/parseCode");
-const parseFile = require("../src/parseFile");
-const verifyReactComponents = require("../src/verifyReactComponents");
-const parseReactComponents = require("../src/parseReactComponents");
+const getParsedCode = require("../src/getParsedCode");
+//const verifyReactComponents = require("../src/verifyReactComponents");
+//const parseReactComponents = require("../src/parseReactComponents");
+const getComponents = require("../src/getComponents");
 
 describe("Extract Data", () => {
   // STATE
@@ -18,9 +19,8 @@ describe("Extract Data", () => {
         return <div>{count} {theme}</div>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.internal.states).toEqual(
         expect.arrayContaining([
@@ -38,9 +38,8 @@ describe("Extract Data", () => {
         return <div>{count} {theme}</div>;
       })
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.internal.states).toEqual(
         expect.arrayContaining([
@@ -59,9 +58,8 @@ describe("Extract Data", () => {
         return <div>{count} {theme}</div>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.internal.states).toEqual(
         expect.arrayContaining([
@@ -84,9 +82,8 @@ describe("Extract Data", () => {
         } 
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.internal.states).toEqual(
         expect.arrayContaining([["color"]]),
@@ -101,9 +98,8 @@ describe("Extract Data", () => {
         return <div>{count} {theme}</div>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`::${fakePath}`];
       expect(component.internal.states).toEqual(
         expect.arrayContaining([
@@ -121,9 +117,8 @@ describe("Extract Data", () => {
         return <div>{count} {theme}</div>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.internal.states).toEqual(
         expect.arrayContaining([
@@ -151,9 +146,8 @@ describe("Extract Data", () => {
     }
   `;
 
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const componentKey = `FunctionExtraction::${fakePath}`;
       const component = result[componentKey];
       const internalFunctions = component.internal.functions;
@@ -172,9 +166,8 @@ describe("Extract Data", () => {
         return <p></p>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`Component::${fakePath}`];
       expect(component.internal.functions).toContain("NestedComponent");
     });
@@ -189,9 +182,8 @@ describe("Extract Data", () => {
       }
     `;
 
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`PropsComponent::${fakePath}`];
       expect(component.external.props).toEqual(
         expect.arrayContaining(["title", "count"]),
@@ -210,9 +202,8 @@ describe("Extract Data", () => {
       }
     `;
 
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`ContextComponent::${fakePath}`];
 
       expect(component.external.context).toEqual(
@@ -233,27 +224,24 @@ describe("Extract Data", () => {
         return <HomePage/>;
       }
     `;
-        const topLevelDeclarations = parseFile(code);
-        const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-        const result = parseReactComponents(verifiedComponents, fakePath);
+        const parsedCode = getParsedCode(code);
+        const result = getComponents(parsedCode, fakePath);
         const component = result[`DescendantsComponent::${fakePath}`];
         expect(component.unresolvedDescendants).toEqual(["HomePage"]);
       });
       test("constant ArrowFunctions, no blockStatement", () => {
         const fakePath = "../fake/DescendantsComponent.js";
         const code = `const DescendantsComponent = () => <HomePage/>;`;
-        const topLevelDeclarations = parseFile(code);
-        const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-        const result = parseReactComponents(verifiedComponents, fakePath);
+        const parsedCode = getParsedCode(code);
+        const result = getComponents(parsedCode, fakePath);
         const component = result[`DescendantsComponent::${fakePath}`];
         expect(component.unresolvedDescendants).toEqual(["HomePage"]);
       });
       test("constant ArrowFunctions, with blockStatement", () => {
         const fakePath = "../fake/DescendantsComponent.js";
         const code = `const DescendantsComponent = () => { return <HomePage/>; }`;
-        const topLevelDeclarations = parseFile(code);
-        const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-        const result = parseReactComponents(verifiedComponents, fakePath);
+        const parsedCode = getParsedCode(code);
+        const result = getComponents(parsedCode, fakePath);
         const component = result[`DescendantsComponent::${fakePath}`];
         expect(component.unresolvedDescendants).toEqual(["HomePage"]);
       });
@@ -266,9 +254,8 @@ describe("Extract Data", () => {
         return <Header></Header>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`DescendantsComponent::${fakePath}`];
       expect(component.unresolvedDescendants).toEqual(["Header"]);
     });
@@ -280,9 +267,8 @@ describe("Extract Data", () => {
         return <Routes><Route><Hello/></Route></Routes>;
       }
     `;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`NestedDescendantsComponent::${fakePath}`];
       expect(component.unresolvedDescendants).toEqual([
         "Routes",
@@ -295,27 +281,24 @@ describe("Extract Data", () => {
     test("export default () =>", () => {
       const fakePath = "../fake/StateComponent.js";
       const code = `export default () => <JSX/>`;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`::${fakePath}`];
       expect(component.defaultExport).toEqual(true);
     });
     test("export default function", () => {
       const fakePath = "../fake/StateComponent.js";
       const code = `export default function StateComponent(){ return <JSX/> }`;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.defaultExport).toEqual(true);
     });
     test("export named", () => {
       const fakePath = "../fake/StateComponent.js";
       const code = `export const StateComponent = () => <JSX/>`;
-      const topLevelDeclarations = parseFile(code);
-      const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-      const result = parseReactComponents(verifiedComponents, fakePath);
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
       const component = result[`StateComponent::${fakePath}`];
       expect(component.defaultExport).toEqual(false);
     });

--- a/tests/dataExtraction.test.js
+++ b/tests/dataExtraction.test.js
@@ -227,7 +227,9 @@ describe("Extract Data", () => {
         const parsedCode = getParsedCode(code);
         const result = getComponents(parsedCode, fakePath);
         const component = result[`DescendantsComponent::${fakePath}`];
-        expect(component.unresolvedDescendants).toEqual(["HomePage"]);
+        expect(Array.from(component.unresolvedDescendants)).toEqual([
+          ["HomePage", ""],
+        ]);
       });
       test("constant ArrowFunctions, no blockStatement", () => {
         const fakePath = "../fake/DescendantsComponent.js";
@@ -235,7 +237,9 @@ describe("Extract Data", () => {
         const parsedCode = getParsedCode(code);
         const result = getComponents(parsedCode, fakePath);
         const component = result[`DescendantsComponent::${fakePath}`];
-        expect(component.unresolvedDescendants).toEqual(["HomePage"]);
+        expect(Array.from(component.unresolvedDescendants)).toEqual([
+          ["HomePage", ""],
+        ]);
       });
       test("constant ArrowFunctions, with blockStatement", () => {
         const fakePath = "../fake/DescendantsComponent.js";
@@ -243,7 +247,9 @@ describe("Extract Data", () => {
         const parsedCode = getParsedCode(code);
         const result = getComponents(parsedCode, fakePath);
         const component = result[`DescendantsComponent::${fakePath}`];
-        expect(component.unresolvedDescendants).toEqual(["HomePage"]);
+        expect(Array.from(component.unresolvedDescendants)).toEqual([
+          ["HomePage", ""],
+        ]);
       });
     });
 
@@ -257,7 +263,9 @@ describe("Extract Data", () => {
       const parsedCode = getParsedCode(code);
       const result = getComponents(parsedCode, fakePath);
       const component = result[`DescendantsComponent::${fakePath}`];
-      expect(component.unresolvedDescendants).toEqual(["Header"]);
+      expect(Array.from(component.unresolvedDescendants)).toEqual([
+        ["Header", ""],
+      ]);
     });
 
     test("nestedDescendants", () => {
@@ -270,10 +278,10 @@ describe("Extract Data", () => {
       const parsedCode = getParsedCode(code);
       const result = getComponents(parsedCode, fakePath);
       const component = result[`NestedDescendantsComponent::${fakePath}`];
-      expect(component.unresolvedDescendants).toEqual([
-        "Routes",
-        "Route",
-        "Hello",
+      expect(Array.from(component.unresolvedDescendants)).toEqual([
+        ["Routes", ""],
+        ["Route", ""],
+        ["Hello", ""],
       ]);
     });
   });

--- a/tests/edgeCases.test.js
+++ b/tests/edgeCases.test.js
@@ -1,18 +1,109 @@
 // edgeCases.test.js
 // Goal: Handle tricky structures like nested components, default exports, and files with missing metadata.
-const parseFile = require("../src/parseFile");
-const verifyReactComponents = require("../src/verifyReactComponents");
-const parseReactComponents = require("../src/parseReactComponents");
+const getParsedCode = require("../src/getParsedCode");
+//const verifyReactComponents = require("../src/verifyReactComponents");
+//const parseReactComponents = require("../src/parseReactComponents");
+const getComponents = require("../src/getComponents");
 
 describe("Edge Cases", () => {
-  test("Extract Component nested in component factory", () => {
-    const fakePath = "../fake/Component.js";
-    const code = `const Component = memo(NestedComponent)`;
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
-    const component = result[`Component::${fakePath}`];
-    expect(component.name).toEqual("Component");
+  describe("Nested Components", () => {
+    test("Extract Component nested in component factory", () => {
+      const fakePath = "../fake/Component.js";
+      const code = `const Component = memo(NestedComponent)`;
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
+      const component = result[`Component::${fakePath}`];
+      expect(component.name).toEqual("Component");
+    });
+    test("Extract Descendant nested in a conditional JS Expression", () => {
+      const fakePath = "../fake/Component.js";
+      const code = `function Component(){ return <>{ condition && <HomePage /> }</> }`;
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
+      const component = result[`Component::${fakePath}`];
+      expect(component.descendants.has("HomePage")).toEqual(true);
+    });
+    test("Extract Descendant nested in a map within a JS Expression: identifier", () => {
+      const fakePath = "../fake/Component.js";
+      const code = `function Component(){ 
+	return <>
+	    { SECTION.map(({id, component})=> {
+	      const Section = component; 
+	      return <Section id={id}/>
+	    }) }
+	</>
+      }`;
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
+      const component = result[`Component::${fakePath}`];
+      expect(component.descendants.has("Section")).toEqual(true);
+      expect(Object.keys(result)).toContain(`Section::${fakePath}`);
+    });
+    test("Extract Descendant nested in a map within a JS Expression: MemberExpression", () => {
+      const fakePath = "../fake/Component.js";
+      const code = `function Component(){ 
+	return <>
+	    { SECTION.map((section)=> {
+	      const Section = section.component; 
+	      return <Section id={section.id}/>
+	    }) }
+	</>
+      }`;
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
+      const component = result[`Component::${fakePath}`];
+      expect(component.descendants.has("Section")).toEqual(true);
+      expect(Object.keys(result)).toContain(`Section::${fakePath}`);
+    });
+
+    test("component with a nested inline component is detected and marked as nested", () => {
+      const fakePath = "../fake/NestedStructure.js";
+      const code = `function NestedStructure() {
+        const Wrapper = () => <div>Nested component</div>;
+        return <Wrapper />;
+       }`;
+
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
+
+      // Assert both top-level components are detected
+      expect(Object.keys(result)).toContain(`NestedStructure::${fakePath}`);
+      expect(Object.keys(result)).toContain(`Wrapper::${fakePath}`);
+
+      // Assert nested flag is set
+      expect(result[`Wrapper::${fakePath}`].nested).toBe(true);
+
+      // Assert function is also tracked in metadata of parent
+      const parentFunctions =
+        result[`NestedStructure::${fakePath}`].internal.functions;
+      expect(parentFunctions).toContain("Wrapper");
+    });
+
+    test("component with a nested function-defined component is detected and marked as nested", () => {
+      const fakePath = "../fake/NestedFunctionStructure.js";
+      const code = `function ParentComponent() {
+        function ChildComponent() {
+          return <span>Nested function-defined</span>;
+        }
+
+        return <ChildComponent />;
+      }`;
+
+      const parsedCode = getParsedCode(code);
+      const result = getComponents(parsedCode, fakePath);
+
+      // Assert both components are detected
+      expect(Object.keys(result)).toContain(`ParentComponent::${fakePath}`);
+      expect(Object.keys(result)).toContain(`ChildComponent::${fakePath}`);
+
+      // Assert nested flag is set
+      expect(result[`ChildComponent::${fakePath}`].nested).toBe(true);
+
+      // Assert function is tracked in parent metadata
+      const parentFunctions =
+        result[`ParentComponent::${fakePath}`].internal.functions;
+      expect(parentFunctions).toContain("ChildComponent");
+    });
   });
 
   test("component with no state variables", () => {
@@ -23,9 +114,8 @@ describe("Edge Cases", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
     const component = result[`NoState::${fakePath}`];
 
     expect(component.internal.states).toEqual([]);
@@ -40,9 +130,8 @@ describe("Edge Cases", () => {
     }
   `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
 
     const internalFunctions =
       result[`NoFunctionsComponent::${fakePath}`].internal.functions;
@@ -57,9 +146,8 @@ describe("Edge Cases", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
     const component = result[`NoProps::${fakePath}`];
 
     expect(component.external.props).toEqual([]);
@@ -73,9 +161,8 @@ describe("Edge Cases", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
     const component = result[`NoContext::${fakePath}`];
 
     expect(component.external.context).toEqual([]);
@@ -89,67 +176,11 @@ describe("Edge Cases", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
     const component = result[`NoConstants::${fakePath}`];
 
     expect(component.external.constants).toEqual([]);
-  });
-
-  test("component with a nested inline component is detected and marked as nested", () => {
-    const fakePath = "../fake/NestedStructure.js";
-    const code = `
-    function NestedStructure() {
-      const Wrapper = () => <div>Nested component</div>;
-      return <Wrapper />;
-    }
-  `;
-
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
-
-    // Assert both top-level components are detected
-    expect(Object.keys(result)).toContain(`NestedStructure::${fakePath}`);
-    expect(Object.keys(result)).toContain(`Wrapper::${fakePath}`);
-
-    // Assert nested flag is set
-    expect(result[`Wrapper::${fakePath}`].nested).toBe(true);
-
-    // Assert function is also tracked in metadata of parent
-    const parentFunctions =
-      result[`NestedStructure::${fakePath}`].internal.functions;
-    expect(parentFunctions).toContain("Wrapper");
-  });
-
-  test("component with a nested function-defined component is detected and marked as nested", () => {
-    const fakePath = "../fake/NestedFunctionStructure.js";
-    const code = `
-    function ParentComponent() {
-      function ChildComponent() {
-        return <span>Nested function-defined</span>;
-      }
-
-      return <ChildComponent />;
-    }
-  `;
-
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
-
-    // Assert both components are detected
-    expect(Object.keys(result)).toContain(`ParentComponent::${fakePath}`);
-    expect(Object.keys(result)).toContain(`ChildComponent::${fakePath}`);
-
-    // Assert nested flag is set
-    expect(result[`ChildComponent::${fakePath}`].nested).toBe(true);
-
-    // Assert function is tracked in parent metadata
-    const parentFunctions =
-      result[`ParentComponent::${fakePath}`].internal.functions;
-    expect(parentFunctions).toContain("ChildComponent");
   });
 });
 
@@ -167,9 +198,8 @@ describe("Exports", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
 
     expect(Object.keys(result)).toContain(
       `DefaultExportStructure::${fakePath}`,
@@ -184,9 +214,8 @@ describe("Exports", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
 
     expect(Object.keys(result)).toContain(`ExportStructure::${fakePath}`);
   });
@@ -199,9 +228,8 @@ describe("Exports", () => {
       }
     `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
 
     expect(Object.keys(result)).toContain(`NamedExportInline::${fakePath}`);
   });
@@ -212,9 +240,8 @@ describe("Exports", () => {
     export default () => <div>Anonymous inline default export</div>;
   `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
 
     // Assert component key exists
     expect(Object.keys(result)).toContain(`::${fakePath}`);
@@ -228,9 +255,8 @@ describe("Exports", () => {
     }
   `;
 
-    const topLevelDeclarations = parseFile(code);
-    const verifiedComponents = verifyReactComponents(topLevelDeclarations);
-    const result = parseReactComponents(verifiedComponents, fakePath);
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
 
     // Assert component key exists
     expect(Object.keys(result)).toContain(`::${fakePath}`);

--- a/tests/edgeCases.test.js
+++ b/tests/edgeCases.test.js
@@ -21,7 +21,7 @@ describe("Edge Cases", () => {
       const parsedCode = getParsedCode(code);
       const result = getComponents(parsedCode, fakePath);
       const component = result[`Component::${fakePath}`];
-      expect(component.descendants.has("HomePage")).toEqual(true);
+      expect(component.unresolvedDescendants.has("HomePage")).toEqual(true);
     });
     test("Extract Descendant nested in a map within a JS Expression: identifier", () => {
       const fakePath = "../fake/Component.js";
@@ -36,8 +36,10 @@ describe("Edge Cases", () => {
       const parsedCode = getParsedCode(code);
       const result = getComponents(parsedCode, fakePath);
       const component = result[`Component::${fakePath}`];
-      expect(component.descendants.has("Section")).toEqual(true);
-      expect(Object.keys(result)).toContain(`Section::${fakePath}`);
+      expect(component.descendants.includes(`Section::${fakePath}`)).toEqual(
+        true,
+      );
+      expect(result[`Section::${fakePath}`]).toBeTruthy();
     });
     test("Extract Descendant nested in a map within a JS Expression: MemberExpression", () => {
       const fakePath = "../fake/Component.js";
@@ -45,6 +47,7 @@ describe("Edge Cases", () => {
 	return <>
 	    { SECTION.map((section)=> {
 	      const Section = section.component; 
+	      const Section2 = () => <Hello/>
 	      return <Section id={section.id}/>
 	    }) }
 	</>
@@ -52,8 +55,9 @@ describe("Edge Cases", () => {
       const parsedCode = getParsedCode(code);
       const result = getComponents(parsedCode, fakePath);
       const component = result[`Component::${fakePath}`];
-      expect(component.descendants.has("Section")).toEqual(true);
-      expect(Object.keys(result)).toContain(`Section::${fakePath}`);
+      expect(component.descendants.includes(`Section::${fakePath}`)).toEqual(
+        true,
+      );
     });
 
     test("component with a nested inline component is detected and marked as nested", () => {

--- a/tests/getParsedCode.test.js
+++ b/tests/getParsedCode.test.js
@@ -1,7 +1,7 @@
 // parseFile.test.js
 // Goal: Validate that file is correctly parsed
 // Cases Covered: imports, exports, constants, functions, classes
-const parseFile = require("../src/parseFile");
+const getParsedCode = require("../src/getParsedCode");
 
 describe("parseFile", () => {
   // START of imports
@@ -9,7 +9,7 @@ describe("parseFile", () => {
     // test 1
     test("ImportDefaultSpecifier", () => {
       const code = `import React from "react";`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const imports = result.imports.map(
         ({ specifier }) => specifier.node.local.name,
       );
@@ -18,7 +18,7 @@ describe("parseFile", () => {
     // test 2
     test("2x ImportSpecifiers", () => {
       const code = `import {Button, Icon} from "@specialPath";`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const imports = result.imports.map(
         ({ specifier }) => specifier.node.local.name,
       );
@@ -27,7 +27,7 @@ describe("parseFile", () => {
     // test 3
     test("1x ImportDefaultSpecifier and 2x ImportSpecifiers", () => {
       const code = `import MyDefault, { NamedExport1, NamedExport2 } from './my-module.js';`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const imports = result.imports.map(
         ({ specifier }) => specifier.node.local.name,
       );
@@ -36,7 +36,7 @@ describe("parseFile", () => {
     // test 4
     test("ImportSpecifier { default as MyComponent}", () => {
       const code = `import { default as MyComponent } from "./my-module.js";`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const imports = result.imports.map(
         ({ specifier }) => specifier.node.local.name,
       );
@@ -49,7 +49,7 @@ describe("parseFile", () => {
     // test 1
     test("default export", () => {
       const code = `export default ()=> <Hi/>`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const exports = result.exports.map(
         ({ declaration }) => declaration.node.type,
       );
@@ -58,7 +58,7 @@ describe("parseFile", () => {
     // test 2
     test("constant", () => {
       const code = `export const ComponentName = <HI/>`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const exports = result.exports.map(
         ({ declaration }) => declaration.node.type,
       );
@@ -67,7 +67,7 @@ describe("parseFile", () => {
     // test 3
     test("function", () => {
       const code = `export function ThereAgain(){}`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const exports = result.exports.map(
         ({ declaration }) => declaration.node.type,
       );
@@ -80,7 +80,7 @@ describe("parseFile", () => {
     // test 1
     test("CallExpression", () => {
       const code = `const App = forwardRef(()=>{})`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const constants = result.constants.map(
         ({ declarator }) => declarator.node.id.name,
       );
@@ -89,7 +89,7 @@ describe("parseFile", () => {
     // test 2
     test("ArrowFunctionExpression with bodyStatement", () => {
       const code = `const App = ()=>{}`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const constants = result.constants.map(
         ({ declarator }) => declarator.node.id.name,
       );
@@ -98,7 +98,7 @@ describe("parseFile", () => {
     // test 3
     test("ArrowFunctionExpression without bodyStatement", () => {
       const code = `const App = ()=><div></div>`;
-      const result = parseFile(code);
+      const result = getParsedCode(code);
       const constants = result.constants.map(
         ({ declarator }) => declarator.node.id.name,
       );

--- a/tests/parseImport.test.js
+++ b/tests/parseImport.test.js
@@ -1,6 +1,6 @@
 /* (parseImport.test.js) Objective: test coverage for ./src/parseImport.js */
 
-const parseFile = require("../src/parseFile");
+const getParsedCode = require("../src/getParsedCode");
 const parseImport = require("../src/parseImport");
 
 describe("parse import", () => {
@@ -71,11 +71,8 @@ describe("parse import", () => {
   ];
   testCases.forEach(({ testName, code, target_specifier, expecting }) => {
     test(String(testName), () => {
-      const topLevelDeclarations = parseFile(code);
-      const result = parseImport(
-        topLevelDeclarations.imports,
-        target_specifier,
-      );
+      const parsedCode = getParsedCode(code);
+      const result = parseImport(parsedCode.imports, target_specifier);
       expect(result).toEqual(expecting);
     });
   });

--- a/tests/verifyReactComponents.test.js
+++ b/tests/verifyReactComponents.test.js
@@ -2,7 +2,7 @@
 // Goal: check that Components are correctly validated
 // Cases Covered: returns JSXElement, contains a hook, nested in component factory, class extends React.Component
 const verifyReactComponents = require("../src/verifyReactComponents");
-const parseFile = require("../src/parseFile");
+const getParsedCode = require("../src/getParsedCode");
 describe("verify react components", () => {
   // indicator 1
   describe("returns JSXElement", () => {
@@ -10,7 +10,7 @@ describe("verify react components", () => {
       // test 1
       test("arrow function, no block statement", () => {
         const code = `const Component = () => <div></div>`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -20,7 +20,7 @@ describe("verify react components", () => {
       // test 2
       test("arrow function, with block statement", () => {
         const code = `const Component = () => { return <div></div> }`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -30,7 +30,7 @@ describe("verify react components", () => {
       // test 3
       test("JSXElement", () => {
         const code = `const Component = <div></div>`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -42,7 +42,7 @@ describe("verify react components", () => {
       // functions
       test("{ return <JSX /> }", () => {
         const code = `function Component() { return <div></div> }`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -51,7 +51,7 @@ describe("verify react components", () => {
       });
       test("{ if(condition) { return <JSX/> } }", () => {
         const code = `function Component() { if(conditionIsTrue) { return <JSX/> } return null; }`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
       });
@@ -60,7 +60,7 @@ describe("verify react components", () => {
     describe("exports", () => {
       test("export default arrow function", () => {
         const code = `export default () => <JSX/>`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -69,7 +69,7 @@ describe("verify react components", () => {
       });
       test("export default arrow function with blockStatement", () => {
         const code = `export default () => { return <JSX/> }`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -78,7 +78,7 @@ describe("verify react components", () => {
       });
       test("export default function", () => {
         const code = `export default function(){ return <JSX/> }`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("returns JSXElement");
         expect(verifiedComponents[0].declaration_type).toEqual(
@@ -91,7 +91,7 @@ describe("verify react components", () => {
   describe("is nested in component factory", () => {
     test("CallExpression", () => {
       const code = `const Component = forwardRef(() => <div></div>)`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain(
         "is nested in component factory",
@@ -116,7 +116,7 @@ describe("verify react components", () => {
 	  }
 	}
 	`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("class extends react");
       expect(verifiedComponents[0].declaration_type).toEqual(
@@ -136,7 +136,7 @@ describe("verify react components", () => {
 	  }
 	}
 	`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("class extends react");
       expect(verifiedComponents[0].declaration_type).toEqual(
@@ -156,7 +156,7 @@ describe("verify react components", () => {
 	  }
 	}
 	`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("class extends react");
       expect(verifiedComponents[0].declaration_type).toEqual(
@@ -176,7 +176,7 @@ describe("verify react components", () => {
 	  }
 	}
 	`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("class extends react");
       expect(verifiedComponents[0].declaration_type).toEqual(
@@ -197,7 +197,7 @@ describe("verify react components", () => {
 	}
 	`;
 
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("class extends react");
       expect(verifiedComponents[0].declaration_type).toEqual(
@@ -213,7 +213,7 @@ describe("verify react components", () => {
 	        const [count, setCount] = useState(0);
 		return <div></div> 
 	}`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("contains a hook");
     });
@@ -223,7 +223,7 @@ describe("verify react components", () => {
 	        const [count, setCount] = React.useState(0);
 		return <div></div> 
 	}`;
-      const topLevelDeclarations = parseFile(code);
+      const topLevelDeclarations = getParsedCode(code);
       const verifiedComponents = verifyReactComponents(topLevelDeclarations);
       expect(verifiedComponents[0].verified).toContain("contains a hook");
     });
@@ -234,7 +234,7 @@ describe("verify react components", () => {
 	        const [count, setCount] = React.useState(0);
 		return <JSX /> 
 	}`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("contains a hook");
       });
@@ -243,7 +243,7 @@ describe("verify react components", () => {
 	        const [count, setCount] = useState(0);
 		return <div></div> 
 	}`;
-        const topLevelDeclarations = parseFile(code);
+        const topLevelDeclarations = getParsedCode(code);
         const verifiedComponents = verifyReactComponents(topLevelDeclarations);
         expect(verifiedComponents[0].verified).toContain("contains a hook");
       });
@@ -253,13 +253,13 @@ describe("verify react components", () => {
 describe("export_types", () => {
   test("named constant", () => {
     const code = `export const ComponentName = () => <JSX />`;
-    const topLevelDeclarations = parseFile(code);
+    const topLevelDeclarations = getParsedCode(code);
     const verifiedComponents = verifyReactComponents(topLevelDeclarations);
     expect(verifiedComponents[0].export_type).toBe("named");
   });
   test("named function", () => {
     const code = `export function ComponentName(){ return <JSX /> }`;
-    const topLevelDeclarations = parseFile(code);
+    const topLevelDeclarations = getParsedCode(code);
     const verifiedComponents = verifyReactComponents(topLevelDeclarations);
     expect(verifiedComponents[0].export_type).toBe("named");
   });


### PR DESCRIPTION
- refactor: optimize getAlias function by reusing parsed AST data
- refactor: rename functions and variables for clarity and to match functionality
- refactor: migrate descendant resolution logic
- test: align tests with refactored data structures
- refactor: rename variable in parseReactComponents.js from 'obj' to 'component'