### PR TITLE
fix descendant detection and import parsing

### DIFF
--- a/src/collectTopLevelDeclarations.js
+++ b/src/collectTopLevelDeclarations.js
@@ -26,14 +26,8 @@ function collectTopLevelDeclarations(program_body) {
           specifiers.forEach((specifier) => {
             const specifier_type = specifier.node.type;
             switch (specifier.node.type) {
-              case "ImportDefaultSpecifier": {
-                topLevelDeclarations.imports.push({
-                  specifier_type,
-                  specifier,
-                  source,
-                });
-                break;
-              }
+              case "ImportNamespaceSpecifier":
+              case "ImportDefaultSpecifier":
               case "ImportSpecifier": {
                 topLevelDeclarations.imports.push({
                   specifier_type,

--- a/src/parseImport.js
+++ b/src/parseImport.js
@@ -10,8 +10,10 @@ function parseImport(importSpecifiers, descendantName) {
   } of importSpecifiers) {
     const localName = specifier.node.local.name;
     const importedName = specifier.node.imported?.name;
-    // case1: 'import ComponentA from './ComponentA'
+    // case1: import ComponentA from './ComponentA'
+    // case2: import * as ComponentB from './file/path'
     switch (specifier_type) {
+      case "ImportNamespaceSpecifier":
       case "ImportDefaultSpecifier": {
         if (localName === descendantName) {
           return { importSource, localName };
@@ -19,8 +21,8 @@ function parseImport(importSpecifiers, descendantName) {
         break;
       }
       case "ImportSpecifier": {
-        // case2: 'import {ComponentA} from './ComponentA'
-        // case3: 'import {ComponentA as A} from './ComponentA'
+        // case3: import {ComponentA} from './ComponentA'
+        // case4: import {ComponentA as A} from './ComponentA'
         if (localName === descendantName) {
           return { importSource, localName, importedName };
         }

--- a/src/parseReactComponents.js
+++ b/src/parseReactComponents.js
@@ -45,7 +45,7 @@ function parseReactComponents(validatedComponents, filepath) {
           filepath,
         };
 
-        // early return in case of
+        // early return when
         if (verified.has("is nested in component factory")) {
           // const Component = memo(OtherComponent)
           // or export const Component = memo(OtherComponent)
@@ -62,7 +62,7 @@ function parseReactComponents(validatedComponents, filepath) {
           ) {
             return component;
           }
-          // otherwise this is probably a forwardRef( () => {} )
+          // otherwise this can be a forwardRef( () => {} )
         }
 
         // correct the scope of componentPath based on init_type
@@ -191,6 +191,7 @@ function parseReactComponents(validatedComponents, filepath) {
         //EXTRACT non-blockstatement COMPONENT DESCENDANTS (e.g. () => JSX in ArrowFunctionExpressions)
         else {
           const returnStatementPath = componentPath.get("body");
+          //EXTRACT COMPONENT DESCENDANTS
           const resolvedDescendant = extractComponentDescendants({
             returnStatementPath,
             component,
@@ -346,6 +347,13 @@ function extractComponentDescendants({
   // When return is <Jsx/>
   if (returnStatementPath.isJSXElement()) {
     result = handleJSXElement(returnStatementPath);
+
+    // And contains JSX
+    returnStatementPath.traverse({
+      JSXElement(elementPath) {
+        handleJSXElement(elementPath);
+      },
+    });
   } else {
     // When return contains JSX
     returnStatementPath.traverse({

--- a/src/verifyReactComponents.js
+++ b/src/verifyReactComponents.js
@@ -283,6 +283,7 @@ function returnsJSXElement(input) {
         case "ArrowFunctionExpression": {
           switch (body_type) {
             // case: const Component = () => <div></div>;
+            case "JSXFragment":
             case "JSXElement": {
               verified.add("returns JSXElement");
               return {

--- a/tests/cases/unresolvedDescendants.cases.js
+++ b/tests/cases/unresolvedDescendants.cases.js
@@ -1,0 +1,152 @@
+// cases/unresolvedDescendants.cases.js
+
+const functionCases = [
+  {
+    name: "Extract descendant",
+    code: `function Component(){ 
+            return <Button></Button>
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["Button"] },
+    },
+  },
+  {
+    name: "Extract self-closing descendant",
+    code: `function Component(){ 
+            return <App />
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["App"] },
+    },
+  },
+  {
+    name: "Extract nested descendant",
+    code: `function Component(){ 
+            return <Layout><Main></Main></Layout>
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["Layout", "Main"] },
+    },
+  },
+  {
+    name: "Extract self-closing nested descendant",
+    code: `function Component(){ 
+            return <Layout><Main/></Layout>
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["Layout", "Main"] },
+    },
+  },
+  {
+    name: "Extract descendant nested in a conditional JS Expression",
+    code: `function Component(){ 
+            return <>{ condition && <HomePage /> }</> 
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["HomePage"] },
+    },
+  },
+];
+
+const exportCases = [
+  {
+    name: "Extract descendant",
+    code: `export function Component(){ 
+            return <Button></Button>
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["Button"] },
+    },
+  },
+  {
+    name: "Extract self-closing descendant",
+    code: `export function Component(){ 
+            return <App />
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["App"] },
+    },
+  },
+  {
+    name: "Extract nested descendant",
+    code: `export function Component(){ 
+            return <Layout><Main></Main></Layout>
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["Layout", "Main"] },
+    },
+  },
+  {
+    name: "Extract self-closing nested descendant",
+    code: `export function Component(){ 
+            return <Layout><Main/></Layout>
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["Layout", "Main"] },
+    },
+  },
+  {
+    name: "Extract descendant nested in a conditional JS Expression",
+    code: `export function Component(){ 
+            return <>{ condition && <HomePage /> }</> 
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["HomePage"] },
+    },
+  },
+];
+
+const defaultExportCases = [
+  {
+    name: "Extract descendant",
+    code: `export default ()=> <Button></Button>`,
+    expected: {
+      components: [""],
+      unresolvedDescendants: { "": ["Button"] },
+    },
+  },
+  {
+    name: "Extract self-closing descendant",
+    code: `export default () => <App />`,
+    expected: {
+      components: [""],
+      unresolvedDescendants: { "": ["App"] },
+    },
+  },
+  {
+    name: "Extract nested descendant",
+    code: `export default () => <Layout><Main></Main></Layout>`,
+    expected: {
+      components: [""],
+      unresolvedDescendants: { "": ["Layout", "Main"] },
+    },
+  },
+  {
+    name: "Extract self-closing nested descendant",
+    code: `export default () => <Layout><Main/></Layout>`,
+    expected: {
+      components: [""],
+      unresolvedDescendants: { "": ["Layout", "Main"] },
+    },
+  },
+  {
+    name: "Extract descendant nested in a conditional JS Expression",
+    code: `export default () => <>{ condition && <HomePage /> }</>`,
+    expected: {
+      components: [""],
+      unresolvedDescendants: { "": ["HomePage"] },
+    },
+  },
+];
+
+module.exports = { functionCases, exportCases, defaultExportCases };

--- a/tests/edgeCases.test.js
+++ b/tests/edgeCases.test.js
@@ -1,8 +1,7 @@
 // edgeCases.test.js
 // Goal: Handle tricky structures like nested components, default exports, and files with missing metadata.
+
 const getParsedCode = require("../src/getParsedCode");
-//const verifyReactComponents = require("../src/verifyReactComponents");
-//const parseReactComponents = require("../src/parseReactComponents");
 const getComponents = require("../src/getComponents");
 
 describe("Edge Cases", () => {

--- a/tests/edgeCases/cases/nestedComponents.cases.js
+++ b/tests/edgeCases/cases/nestedComponents.cases.js
@@ -1,0 +1,76 @@
+// edgeCases/cases/nestedComponents.cases.js
+
+const cases = [
+  {
+    name: "Extract Component nested in component factory",
+    code: `const Component = memo(NestedComponent);`,
+    expected: { components: ["Component"] },
+  },
+  {
+    name: "Extract Descendant nested in a conditional JS Expression",
+    code: `function Component(){ 
+	    return <>{ condition && <HomePage /> }</> 
+           }`,
+    expected: {
+      components: ["Component"],
+      unresolvedDescendants: { Component: ["HomePage"] },
+    },
+  },
+  {
+    name: "Extract Descendant nested in a map within a JS Expression: identifier",
+    code: `function Component(){ 
+        return <>
+            { SECTION.map(({id, component})=> {
+              const Section = component; 
+              return <Section id={id}/>
+            }) }
+        </>
+      }`,
+    expected: {
+      components: ["Component", "Section"],
+      descendants: { Component: ["Section"] },
+    },
+  },
+  {
+    name: "Extract Descendant nested in a map within a JS Expression: MemberExpression",
+    code: `function Component(){ 
+        return <>
+            { SECTION.map((section)=> {
+              const Section = section.component; 
+              const Section2 = () => <Hello/>
+              return <Section id={section.id}/>
+            }) }
+        </>
+      }`,
+    expected: {
+      components: ["Component", "Section"],
+      descendants: { Component: "Section" },
+    },
+  },
+  {
+    name: "component with a nested inline component is detected and marked as nested",
+    code: `function NestedStructure() {
+        const Wrapper = () => <div>Nested component</div>;
+        return <Wrapper />;
+       }`,
+    expected: {
+      components: ["NestedStructure", "Wrapper"],
+      descendants: { NestedStructure: "Wrapper" },
+    },
+  },
+  {
+    name: "component with a nested function-defined component is detected and marked as nested",
+    code: `function ParentComponent() {
+        function ChildComponent() {
+          return <span>Nested function-defined</span>;
+        }
+        return <ChildComponent />;
+      }`,
+    expected: {
+      components: ["ParentComponent", "ChildComponent"],
+      descendants: { ParentComponent: "ChildComponent" },
+    },
+  },
+];
+
+module.exports = cases;

--- a/tests/edgeCases/nestedComponents.test.js
+++ b/tests/edgeCases/nestedComponents.test.js
@@ -1,0 +1,143 @@
+// file: edgeCases/nestedComponents.test.js
+// goal: handle tricky structures
+
+const cases = require("./cases/nestedComponents.cases.js");
+
+const getParsedCode = require("../../src/getParsedCode");
+const getComponents = require("../../src/getComponents");
+
+// resolved descendants format: ["tagNameA::filePath", "tagNameB::filePath", ...]
+// unresolved descendants format: Map (tagName => filePath)
+
+describe("Nested Components", () => {
+  cases.forEach((testCase) => {
+    const { name, code, expected } = testCase;
+    const fakePath = "../fake/Component.js";
+    test(name, () => {
+      const parsedCode = getParsedCode(code);
+      // component objects
+      const components = Object.values(getComponents(parsedCode, fakePath));
+      // for each component object, check that component exists
+      expect(components.map((component) => component.name)).toEqual(
+        expected.components,
+      );
+      // for each component object, check that descendants were parsed
+      components.forEach((component) => {
+        component.descendants.forEach((descendant) => {
+          const expected_descendants =
+            expected?.descendants[component.name] + `::${fakePath}`;
+          expect(descendant).toEqual(expected_descendants);
+        });
+        const expected_unresolvedDescendants =
+          expected.unresolvedDescendants &&
+          expected.unresolvedDescendants[component.name]
+            ? expected.unresolvedDescendants[component.name]
+            : [];
+        const unresolvedDescendants = Array.from(
+          component.unresolvedDescendants.keys(),
+        );
+        expect(unresolvedDescendants).toEqual(expected_unresolvedDescendants);
+      });
+    });
+  });
+  /*
+  test("Extract Component nested in component factory", () => {
+    const fakePath = "../fake/Component.js";
+    const code = `const Component = memo(NestedComponent)`;
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
+    const component = result[`Component::${fakePath}`];
+    expect(component.name).toEqual("Component");
+  });
+  test("Extract Descendant nested in a conditional JS Expression", () => {
+    const fakePath = "../fake/Component.js";
+    const code = `function Component(){ return <>{ condition && <HomePage /> }</> }`;
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
+    const component = result[`Component::${fakePath}`];
+    expect(component.unresolvedDescendants.has("HomePage")).toEqual(true);
+  });
+  test("Extract Descendant nested in a map within a JS Expression: identifier", () => {
+    const fakePath = "../fake/Component.js";
+    const code = `function Component(){ 
+        return <>
+            { SECTION.map(({id, component})=> {
+              const Section = component; 
+              return <Section id={id}/>
+            }) }
+        </>
+      }`;
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
+    const component = result[`Component::${fakePath}`];
+    expect(component.unresolvedDescendants.has("Section")).toEqual(true);
+    console.log(result);
+    expect(result[`Section::${fakePath}`]).toBeTruthy();
+  });
+  test("Extract Descendant nested in a map within a JS Expression: MemberExpression", () => {
+    const fakePath = "../fake/Component.js";
+    const code = `function Component(){ 
+        return <>
+            { SECTION.map((section)=> {
+              const Section = section.component; 
+              const Section2 = () => <Hello/>
+              return <Section id={section.id}/>
+            }) }
+        </>
+      }`;
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
+    const component = result[`Component::${fakePath}`];
+    expect(component.unresolvedDescendants.has("Section")).toEqual(true);
+  });
+
+  test("component with a nested inline component is detected and marked as nested", () => {
+    const fakePath = "../fake/NestedStructure.js";
+    const code = `function NestedStructure() {
+        const Wrapper = () => <div>Nested component</div>;
+        return <Wrapper />;
+       }`;
+
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
+
+    // Assert both top-level components are detected
+    expect(Object.keys(result)).toContain(`NestedStructure::${fakePath}`);
+    expect(Object.keys(result)).toContain(`Wrapper::${fakePath}`);
+
+    // Assert nested flag is set
+    expect(result[`Wrapper::${fakePath}`].nested).toBe(true);
+
+    // Assert function is also tracked in metadata of parent
+    const parentFunctions =
+      result[`NestedStructure::${fakePath}`].internal.functions;
+    expect(parentFunctions).toContain("Wrapper");
+  });
+
+  test("component with a nested function-defined component is detected and marked as nested", () => {
+    const fakePath = "../fake/NestedFunctionStructure.js";
+    const code = `function ParentComponent() {
+        function ChildComponent() {
+          return <span>Nested function-defined</span>;
+        }
+
+        return <ChildComponent />;
+      }`;
+
+    const parsedCode = getParsedCode(code);
+    const result = getComponents(parsedCode, fakePath);
+
+    // Assert both components are detected
+    expect(Object.keys(result)).toContain(`ParentComponent::${fakePath}`);
+    expect(Object.keys(result)).toContain(`ChildComponent::${fakePath}`);
+
+    // Assert nested flag is set
+    expect(result[`ChildComponent::${fakePath}`].nested).toBe(true);
+
+    // Assert function is tracked in parent metadata
+    const parentFunctions =
+      result[`ParentComponent::${fakePath}`].internal.functions;
+    expect(parentFunctions).toContain("ChildComponent");
+  });
+  */
+});

--- a/tests/parseImport.test.js
+++ b/tests/parseImport.test.js
@@ -68,6 +68,25 @@ describe("parse import", () => {
       target_specifier: "Y",
       expecting: { importSource: "./Y", localName: "Y", importedName: "Y" },
     },
+    {
+      testName: "import from node_modules",
+      code: `import { Route } from "react-router-dom";`,
+      target_specifier: "Route",
+      expecting: {
+        importSource: "react-router-dom",
+        importedName: "Route",
+        localName: "Route",
+      },
+    },
+    {
+      testName: "import * as specifier",
+      code: `import * as Dialogue from "@radix-ui/react-dialogue";`,
+      target_specifier: "Dialogue",
+      expecting: {
+        importSource: "@radix-ui/react-dialogue",
+        localName: "Dialogue",
+      },
+    },
   ];
   testCases.forEach(({ testName, code, target_specifier, expecting }) => {
     test(String(testName), () => {

--- a/tests/unresolvedDescendants.test.js
+++ b/tests/unresolvedDescendants.test.js
@@ -1,0 +1,56 @@
+// file: unresolvedDescendants.test.js
+// goal: collects unresolved descendants
+
+const {
+  functionCases,
+  exportCases,
+  defaultExportCases,
+} = require("./cases/unresolvedDescendants.cases.js");
+
+const getParsedCode = require("../src/getParsedCode");
+const getComponents = require("../src/getComponents");
+
+// resolved descendants format: ["tagNameA::filePath", "tagNameB::filePath", ...]
+// unresolved descendants format: Map (tagName => filePath)
+describe("(functions) Identify unresolved descendants", () => {
+  check(functionCases);
+});
+describe("(exports) Identify unresolved descendants", () => {
+  check(exportCases);
+});
+describe("(export defaults) Identify unresolved descendants", () => {
+  check(defaultExportCases);
+});
+
+function check(cases) {
+  cases.forEach((testCase) => {
+    const { name, code, expected } = testCase;
+    const fakePath = "../fake/Component.js";
+    test(name, () => {
+      const parsedCode = getParsedCode(code);
+      // component objects
+      const components = Object.values(getComponents(parsedCode, fakePath));
+      // for each component object, check that component exists
+      expect(components.map((component) => component.name)).toEqual(
+        expected.components,
+      );
+      // for each component object, check that descendants were parsed
+      components.forEach((component) => {
+        component.descendants.forEach((descendant) => {
+          const expected_descendants =
+            expected?.descendants[component.name] + `::${fakePath}`;
+          expect(descendant).toEqual(expected_descendants);
+        });
+        const expected_unresolvedDescendants =
+          expected.unresolvedDescendants &&
+          expected.unresolvedDescendants[component.name]
+            ? expected.unresolvedDescendants[component.name]
+            : [];
+        const unresolvedDescendants = Array.from(
+          component.unresolvedDescendants.keys(),
+        );
+        expect(unresolvedDescendants).toEqual(expected_unresolvedDescendants);
+      });
+    });
+  });
+}


### PR DESCRIPTION
- fix: component verification and descendant detection
- test: add test suite for unresolved descendants and nested components
- fix: add support for ImportNamespaceSpecifier in import parsing
- test: add test cases for node_modules and namespace imports