### PR TITLE
chore: bump version to v0.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-diagram-schema",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-diagram-schema",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-diagram-schema",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "CLI tool that parses React components and generates a structured JSON schema capturing component hierarchy, state, props, and context",
   "main": "./src/build-schema.js",
   "scripts": {


### PR DESCRIPTION
- Run `npm version 0.3.10 --no-git-tag-version`